### PR TITLE
EXPERIMENTAL FEATURE: API Overview Page

### DIFF
--- a/firefly/utils.py
+++ b/firefly/utils.py
@@ -13,6 +13,11 @@ def json_encode(data):
 def is_file(obj):
     return hasattr(obj, "read")
 
+def get_template_path():
+    firefly_module = __import__('firefly')
+    file = firefly_module.__file__
+    return '/'.join(file.split('/')[:-1]) + '/templates'
+
 class FileIter:
     def __init__(self, fileobj, chunk_size=4096):
         self.fileobj = fileobj


### PR DESCRIPTION
Currently, the firefly application serves a `json` docs page at '/`.

The motive is to beautify that data in the form of HTML pages and add features such as trying out the API endpoint from the page itself.

TODO's
[x] Add a basic for POC
[ ] Deciding on a path to host the the page. Currently, it is at `/index.html` to prevent any conflicts
[ ] Add support to firefly to accept an API name parameter through firefly.yml
[ ] Add testing features

More feature suggestions are welcome